### PR TITLE
storage.length check is a wrong way to check for an existence of a key

### DIFF
--- a/js/Main.jsx
+++ b/js/Main.jsx
@@ -15,7 +15,7 @@ var Main = React.createClass({
   componentDidMount: function() {
     var _this = this;
     var storage = localStorage;
-    if(storage.length == 1){
+    if(storage.getItem("livewire") !== null){
       var data = JSON.parse(storage.getItem("livewire"));
       _this.setState({
         response : true,


### PR DESCRIPTION
Reason the new plugin keeps going in a loop is because of length check. In the first version (indixportal) the key was called "data".
Ref 
- http://stackoverflow.com/questions/3262605/html5-localstorage-check-if-item-is-set
- http://www.w3.org/TR/webstorage/#dom-storage-getitem
